### PR TITLE
Call terminate

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -95,21 +95,25 @@ public final class SpoonRunner {
 
     AndroidDebugBridge adb = SpoonUtils.initAdb(androidSdk);
 
-    // If we were given an empty serial set, load all available devices.
-    Set<String> serials = this.serials;
-    if (serials.isEmpty()) {
-      serials = SpoonUtils.findAllDevices(adb);
-    }
-    if (failIfNoDeviceConnected && serials.isEmpty()) {
-      throw new RuntimeException("No device(s) found.");
-    }
+    try {
+      // If we were given an empty serial set, load all available devices.
+      Set<String> serials = this.serials;
+      if (serials.isEmpty()) {
+        serials = SpoonUtils.findAllDevices(adb);
+      }
+      if (failIfNoDeviceConnected && serials.isEmpty()) {
+        throw new RuntimeException("No device(s) found.");
+      }
 
-    // Execute all the things...
-    SpoonSummary summary = runTests(adb, serials);
-    // ...and render to HTML
-    new HtmlRenderer(summary, SpoonUtils.GSON, output).render();
+      // Execute all the things...
+      SpoonSummary summary = runTests(adb, serials);
+      // ...and render to HTML
+      new HtmlRenderer(summary, SpoonUtils.GSON, output).render();
 
-    return parseOverallSuccess(summary);
+      return parseOverallSuccess(summary);
+    } finally {
+      AndroidDebugBridge.terminate();
+    }
   }
 
   private SpoonSummary runTests(AndroidDebugBridge adb, Set<String> serials) {


### PR DESCRIPTION
Partially reverts #246.
Terminate should stop a couple of threads used by the bridge.
Should close #251.

disconnectBridge() is not back because it kills adb server,
which is what we are trying to avoid (see #247).

See also https://groups.google.com/forum/#!topic/adt-dev/1BgTs8Bs6_Q
